### PR TITLE
Deserialization

### DIFF
--- a/Scarb.toml
+++ b/Scarb.toml
@@ -1,6 +1,3 @@
 [package]
 name = "cairo_verifier"
 version = "0.1.0"
-
-[lib]
-sierra-text = true

--- a/run.sh
+++ b/run.sh
@@ -2,4 +2,4 @@
 
 scarb build
 cd runner
-cargo run --release -- ../target/dev/cairo_verifier.sierra < resources/parserin.txt
+cargo run --release -- ../target/dev/cairo_verifier.sierra.json < resources/parserin.txt

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.76"
-cairo-args-runner = "0.1.1"
+cairo-args-runner = "1.0.0"
 clap = { version = "4.4.11", features = ["derive"] }
 lalrpop-util = { version = "0.20.0", features = ["lexer", "unicode"] }
 serde = { version = "1.0.193", features = ["derive"] }

--- a/runner/src/ast.rs
+++ b/runner/src/ast.rs
@@ -12,7 +12,7 @@ pub enum Expr {
 impl Display for Expr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Expr::Value(v) => write!(f, "{v}"),
+            Expr::Value(v) => write!(f, "\"{v}\""),
             Expr::Array(v) => {
                 write!(f, "[")?;
 

--- a/runner/src/ast.rs
+++ b/runner/src/ast.rs
@@ -26,7 +26,7 @@ impl Display for Expr {
                 write!(f, "]")?;
 
                 Ok(())
-            },
+            }
         }
     }
 }

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -23,7 +23,7 @@ fn main() -> anyhow::Result<()> {
     let parsed = parser::CairoParserOutputParser::new()
         .parse(&input)
         .map_err(|e| anyhow::anyhow!("{}", e))?;
-    let result = format!("{parsed}");
+    let result = parsed.to_string();
 
     let target = cli.target;
     let function = "main";

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -29,7 +29,7 @@ fn main() -> anyhow::Result<()> {
     let function = "main";
     let args: VecFelt252 = serde_json::from_str(&result).unwrap();
 
-    let result = run(&target, &function, &[Arg::Array(args.to_vec())])?;
+    let result = run(&target, function, &[Arg::Array(args.to_vec())])?;
 
     println!("{result:?}");
     Ok(())

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -1,6 +1,6 @@
 use std::io::{stdin, Read};
 
-use cairo_args_runner::{run, WrappedArg};
+use cairo_args_runner::{run, Arg, VecFelt252};
 use clap::Parser;
 use lalrpop_util::lalrpop_mod;
 
@@ -27,9 +27,9 @@ fn main() -> anyhow::Result<()> {
 
     let target = cli.target;
     let function = "main";
-    let args: WrappedArg = serde_json::from_str(&result).unwrap();
+    let args: VecFelt252 = serde_json::from_str(&result).unwrap();
 
-    let result = run(&target, &function, &args)?;
+    let result = run(&target, &function, &[Arg::Array(args.to_vec())])?;
 
     println!("{result:?}");
     Ok(())

--- a/runner/src/parser.lalrpop
+++ b/runner/src/parser.lalrpop
@@ -20,12 +20,12 @@ Arg: Exprs = {
 };
 
 FriWitnessLayers: Exprs = {
-    <n:Num> "," "[" <a:Comma<Num>> "]" => Exprs(vec![Expr::Value(n)].into_iter().chain(a.into_iter().map(|x| Expr::Value(x))).collect()),
+    <n:Num> "," "[" <a:Comma<Num>> "]" => Exprs(vec![Expr::Value(n)].into_iter().chain(a.into_iter().map(Expr::Value)).collect()),
     StructName "(" ArgName "=" StructName "(" <n:FriWitnessLayersArgs> ")" ")" => n,
 };
 
 FriWitnessLayersArgs: Exprs = {
-    ArgName "=" <n:Num> "," ArgName "=" "[" <a:Comma<Num>> "]" => Exprs(vec![Expr::Value(n)].into_iter().chain(a.into_iter().map(|x| Expr::Value(x))).collect()),
+    ArgName "=" <n:Num> "," ArgName "=" "[" <a:Comma<Num>> "]" => Exprs(vec![Expr::Value(n)].into_iter().chain(a.into_iter().map(Expr::Value)).collect()),
 };
 
 Comma<T>: Vec<T> = {

--- a/runner/src/parser.lalrpop
+++ b/runner/src/parser.lalrpop
@@ -11,11 +11,21 @@ CairoParserOutputInner: Exprs = {
     <n:Num> => Exprs(vec![Expr::Value(n)]),
     "[" <n:Comma<CairoParserOutputInner>> "]" => Exprs(vec![Expr::Array(n.iter().flat_map(|x| x.iter().cloned()).collect())]),
     StructName "()" => Exprs(Vec::new()),
+    "FriWitness" "(" "layers=" "[" <n:Comma<FriWitnessLayers>> "]" ")" => Exprs(vec![Expr::Array(n.iter().flat_map(|x| x.iter().cloned()).collect())]),
     StructName "(" <n:Comma<Arg>> ")" => Exprs(n.iter().flat_map(|x| x.iter().cloned()).collect()),
 };
 
 Arg: Exprs = {
     ArgName "=" <n:CairoParserOutputInner> => n,
+};
+
+FriWitnessLayers: Exprs = {
+    <n:Num> "," "[" <a:Comma<Num>> "]" => Exprs(vec![Expr::Value(n)].into_iter().chain(a.into_iter().map(|x| Expr::Value(x))).collect()),
+    StructName "(" ArgName "=" StructName "(" <n:FriWitnessLayersArgs> ")" ")" => n,
+};
+
+FriWitnessLayersArgs: Exprs = {
+    ArgName "=" <n:Num> "," ArgName "=" "[" <a:Comma<Num>> "]" => Exprs(vec![Expr::Value(n)].into_iter().chain(a.into_iter().map(|x| Expr::Value(x))).collect()),
 };
 
 Comma<T>: Vec<T> = {

--- a/src/input_structs.cairo
+++ b/src/input_structs.cairo
@@ -1,3 +1,4 @@
 mod public_input;
 mod stark_config;
 mod stark_proof;
+mod stark_unsent_commitment;

--- a/src/input_structs.cairo
+++ b/src/input_structs.cairo
@@ -1,2 +1,3 @@
+mod public_input;
 mod stark_config;
 mod stark_proof;

--- a/src/input_structs.cairo
+++ b/src/input_structs.cairo
@@ -2,3 +2,4 @@ mod public_input;
 mod stark_config;
 mod stark_proof;
 mod stark_unsent_commitment;
+mod stark_witness;

--- a/src/input_structs/public_input.cairo
+++ b/src/input_structs/public_input.cairo
@@ -1,0 +1,16 @@
+#[derive(Drop, Serde)]
+struct PublicInput {
+    log_n_steps: felt252,
+    range_check_min: felt252,
+    range_check_max: felt252,
+    layout: felt252,
+    dynamic_params: Array<felt252>,
+    n_segments: felt252,
+    segments: Array<felt252>,
+    padding_addr: felt252,
+    padding_value: felt252,
+    main_page_len: felt252,
+    main_page: Array<felt252>,
+    n_continuous_pages: felt252,
+    continuous_page_headers: Array<felt252>,
+}

--- a/src/input_structs/stark_config.cairo
+++ b/src/input_structs/stark_config.cairo
@@ -1,4 +1,4 @@
-#[derive(Copy, Drop)]
+#[derive(Copy, Drop, Serde)]
 struct StarkConfig {
     traces: TracesConfig,
     composition: TableCommitmentConfig,
@@ -15,25 +15,25 @@ struct StarkConfig {
 // n_verifier_friendly_commitment_layers: felt252,
 }
 
-#[derive(Copy, Drop)]
+#[derive(Copy, Drop, Serde)]
 struct TracesConfig {
     original: TableCommitmentConfig,
     interaction: TableCommitmentConfig,
 }
 
-#[derive(Copy, Drop)]
+#[derive(Copy, Drop, Serde)]
 struct TableCommitmentConfig {
     columns: felt252,
     vector: VectorCommitmentConfig
 }
 
-#[derive(Copy, Drop)]
+#[derive(Copy, Drop, Serde)]
 struct VectorCommitmentConfig {
     height: felt252,
     verifier_friendly_commitment_layers: felt252,
 }
 
-#[derive(Copy, Drop)]
+#[derive(Copy, Drop, Serde)]
 struct FriConfig {
     // Log2 of the size of the input layer to FRI.
     log_input_size: felt252,
@@ -48,7 +48,7 @@ struct FriConfig {
     log_last_layer_degree_bound: felt252,
 }
 
-#[derive(Copy, Drop)]
+#[derive(Copy, Drop, Serde)]
 struct ProofOfWorkConfig {
     // Proof of work difficulty (number of bits required to be 0).
     n_bits: felt252,

--- a/src/input_structs/stark_config.cairo
+++ b/src/input_structs/stark_config.cairo
@@ -1,39 +1,39 @@
-#[derive(Copy, Drop, Serde)]
+#[derive(Drop, Serde)]
 struct StarkConfig {
     traces: TracesConfig,
     composition: TableCommitmentConfig,
-// fri: FriConfig,
-// proof_of_work: ProofOfWorkConfig,
-// // Log2 of the trace domain size.
-// log_trace_domain_size: felt252,
-// // Number of queries to the last component, FRI.
-// n_queries: felt252,
-// // Log2 of the number of cosets composing the evaluation domain, where the coset size is the
-// // trace length.
-// log_n_cosets: felt252,
-// // Number of layers that use a verifier friendly hash in each commitment.
-// n_verifier_friendly_commitment_layers: felt252,
+    fri: FriConfig,
+    proof_of_work: ProofOfWorkConfig,
+    // Log2 of the trace domain size.
+    log_trace_domain_size: felt252,
+    // Number of queries to the last component, FRI.
+    n_queries: felt252,
+    // Log2 of the number of cosets composing the evaluation domain, where the coset size is the
+    // trace length.
+    log_n_cosets: felt252,
+    // Number of layers that use a verifier friendly hash in each commitment.
+    n_verifier_friendly_commitment_layers: felt252,
 }
 
-#[derive(Copy, Drop, Serde)]
+#[derive(Drop, Serde)]
 struct TracesConfig {
     original: TableCommitmentConfig,
     interaction: TableCommitmentConfig,
 }
 
-#[derive(Copy, Drop, Serde)]
+#[derive(Drop, Serde)]
 struct TableCommitmentConfig {
     columns: felt252,
     vector: VectorCommitmentConfig
 }
 
-#[derive(Copy, Drop, Serde)]
+#[derive(Drop, Serde)]
 struct VectorCommitmentConfig {
     height: felt252,
     verifier_friendly_commitment_layers: felt252,
 }
 
-#[derive(Copy, Drop, Serde)]
+#[derive(Drop, Serde)]
 struct FriConfig {
     // Log2 of the size of the input layer to FRI.
     log_input_size: felt252,
@@ -41,14 +41,14 @@ struct FriConfig {
     n_layers: felt252,
     // Array of size n_layers - 1, each entry is a configuration of a table commitment for the
     // corresponding inner layer.
-    inner_layers: TableCommitmentConfig,
+    inner_layers: Array<felt252>,
     // Array of size n_layers, each entry represents the FRI step size,
     // i.e. the number of FRI-foldings between layer i and i+1.
-    fri_step_sizes: felt252,
+    fri_step_sizes: Array<felt252>,
     log_last_layer_degree_bound: felt252,
 }
 
-#[derive(Copy, Drop, Serde)]
+#[derive(Drop, Serde)]
 struct ProofOfWorkConfig {
     // Proof of work difficulty (number of bits required to be 0).
     n_bits: felt252,

--- a/src/input_structs/stark_proof.cairo
+++ b/src/input_structs/stark_proof.cairo
@@ -1,6 +1,6 @@
 use cairo_verifier::input_structs::{
     stark_config::StarkConfig, public_input::PublicInput,
-    stark_unsent_commitment::StarkUnsentCommitment,
+    stark_unsent_commitment::StarkUnsentCommitment, stark_witness::StarkWitness,
 };
 
 
@@ -9,5 +9,5 @@ struct StarkProof {
     config: StarkConfig,
     public_input: PublicInput,
     unsent_commitment: StarkUnsentCommitment,
-// witness: StarkWitness,
+    witness: StarkWitness,
 }

--- a/src/input_structs/stark_proof.cairo
+++ b/src/input_structs/stark_proof.cairo
@@ -1,6 +1,6 @@
 use cairo_verifier::input_structs::stark_config::StarkConfig;
 
-#[derive(Copy, Drop)]
+#[derive(Copy, Drop, Serde)]
 struct StarkProof {
     config: StarkConfig,
 // public_input: PublicInput,

--- a/src/input_structs/stark_proof.cairo
+++ b/src/input_structs/stark_proof.cairo
@@ -1,9 +1,11 @@
 use cairo_verifier::input_structs::stark_config::StarkConfig;
+use cairo_verifier::input_structs::public_input::PublicInput;
+
 
 #[derive(Drop, Serde)]
 struct StarkProof {
     config: StarkConfig,
-// public_input: PublicInput,
+    public_input: PublicInput,
 // unsent_commitment: StarkUnsentCommitment,
 // witness: StarkWitness,
 }

--- a/src/input_structs/stark_proof.cairo
+++ b/src/input_structs/stark_proof.cairo
@@ -1,11 +1,13 @@
-use cairo_verifier::input_structs::stark_config::StarkConfig;
-use cairo_verifier::input_structs::public_input::PublicInput;
+use cairo_verifier::input_structs::{
+    stark_config::StarkConfig, public_input::PublicInput,
+    stark_unsent_commitment::StarkUnsentCommitment,
+};
 
 
 #[derive(Drop, Serde)]
 struct StarkProof {
     config: StarkConfig,
     public_input: PublicInput,
-// unsent_commitment: StarkUnsentCommitment,
+    unsent_commitment: StarkUnsentCommitment,
 // witness: StarkWitness,
 }

--- a/src/input_structs/stark_proof.cairo
+++ b/src/input_structs/stark_proof.cairo
@@ -1,6 +1,6 @@
 use cairo_verifier::input_structs::stark_config::StarkConfig;
 
-#[derive(Copy, Drop, Serde)]
+#[derive(Drop, Serde)]
 struct StarkProof {
     config: StarkConfig,
 // public_input: PublicInput,

--- a/src/input_structs/stark_unsent_commitment.cairo
+++ b/src/input_structs/stark_unsent_commitment.cairo
@@ -1,0 +1,25 @@
+#[derive(Drop, Serde)]
+struct StarkUnsentCommitment {
+    traces: TracesUnsentCommitment,
+    composition: felt252,
+    oods_values: Array<felt252>,
+    fri: FriUnsentCommitment,
+    proof_of_work: ProofOfWorkUnsentCommitment,
+}
+
+#[derive(Drop, Serde)]
+struct TracesUnsentCommitment {
+    original: felt252,
+    interaction: felt252,
+}
+
+#[derive(Drop, Serde)]
+struct FriUnsentCommitment {
+    inner_layers: Array<felt252>,
+    last_layer_coefficients: Array<felt252>,
+}
+
+#[derive(Drop, Serde)]
+struct ProofOfWorkUnsentCommitment {
+    nonce: felt252,
+}

--- a/src/input_structs/stark_witness.cairo
+++ b/src/input_structs/stark_witness.cairo
@@ -5,6 +5,7 @@ struct StarkWitness {
     interaction: TableCommitmentWitness,
     composition_decommitment: TableDecommitment,
     composition_witness: TableCommitmentWitness,
+    fri_witness: FriWitness,
 }
 
 #[derive(Drop, Serde)]
@@ -37,5 +38,5 @@ struct VectorCommitmentWitness {
 
 #[derive(Drop, Serde)]
 struct FriWitness {
-    layers: Array<Array<felt252>>,
+    layers: Array<felt252>,
 }

--- a/src/input_structs/stark_witness.cairo
+++ b/src/input_structs/stark_witness.cairo
@@ -1,0 +1,41 @@
+#[derive(Drop, Serde)]
+struct StarkWitness {
+    traces_decommitment: TracesDecommitment,
+    traces_witness: TracesWitness,
+    interaction: TableCommitmentWitness,
+    composition_decommitment: TableDecommitment,
+    composition_witness: TableCommitmentWitness,
+}
+
+#[derive(Drop, Serde)]
+struct TracesDecommitment {
+    original: TableDecommitment,
+    interaction: TableDecommitment,
+}
+
+#[derive(Drop, Serde)]
+struct TableDecommitment {
+    n_values: felt252,
+    values: Array<felt252>,
+}
+
+#[derive(Drop, Serde)]
+struct TracesWitness {
+    original: TableCommitmentWitness,
+}
+
+#[derive(Drop, Serde)]
+struct TableCommitmentWitness {
+    vector: VectorCommitmentWitness,
+}
+
+#[derive(Drop, Serde)]
+struct VectorCommitmentWitness {
+    n_authentications: felt252,
+    authentications: Array<felt252>,
+}
+
+#[derive(Drop, Serde)]
+struct FriWitness {
+    layers: Array<Array<felt252>>,
+}

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -8,6 +8,9 @@ mod vector_commitment;
 
 use cairo_verifier::input_structs::stark_proof::StarkProof;
 
-fn main(stark_proof: StarkProof) -> (felt252, felt252) {
+
+fn main(x: Array<felt252>) -> (felt252, felt252) {
+    let mut x_span = x.span();
+    let stark_proof: StarkProof = Serde::deserialize(ref x_span).unwrap();
     (stark_proof.config.traces.original.columns, stark_proof.config.traces.interaction.columns)
 }

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -9,8 +9,7 @@ mod vector_commitment;
 use cairo_verifier::input_structs::stark_proof::StarkProof;
 
 
-fn main(x: Array<felt252>) -> (felt252, felt252) {
+fn main(x: Array<felt252>) {
     let mut x_span = x.span();
     let stark_proof: StarkProof = Serde::deserialize(ref x_span).unwrap();
-    (stark_proof.config.traces.original.columns, stark_proof.config.traces.interaction.columns)
 }


### PR DESCRIPTION
Whole deserialization works.
You can simply follow the instructions in [Runner Readme](https://github.com/HerodotusDev/cairo-verifier/blob/main/runner/README.md) and copy the whole file from Python parser without any modifications to the `runner/resources/parsein.txt`.

- I've destructed [FriConfig - inner_layers](https://github.com/HerodotusDev/cairo-verifier/blob/deserialization/src/input_structs/stark_config.cairo#L44) into `Array<felt252>` but it is array of `(felt252, VectorCommitmentConfig)`. To support that we need the parser to somehow encode underlying objects structure, because it needs to know how many elements are there in the array - to know that it needs to know the size of the structs inside array.

- I've also destructed [FriWitness - layers](https://github.com/HerodotusDev/cairo-verifier/blob/deserialization/src/input_structs/stark_witness.cairo#L39-L42) into `Array<felt252>`  (that was the case where we had nested arrays) for simplicity, but we can try to deserialize it using `Serde` or enhance parser further to support objects in arrays.